### PR TITLE
Updating GoLang to 1.18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.16'
+        go-version: '1.18'
       id: go
 
     - name: Check out code into the Go module directory
@@ -59,7 +59,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.16'
+        go-version: '1.18'
       id: go
 
     - name: Check out code into the Go module directory


### PR DESCRIPTION
Update to GoLang to 1.18 to support terraform-plugin-sdk v2.21.0