### PR TITLE
Removing EditorConfig

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
 		"golang.Go",
         "GitHub.vscode-pull-request-github",
 		"eamodio.gitlens",
-		"EditorConfig.EditorConfig",
 		"oderwat.indent-rainbow",
 		"DavidAnson.vscode-markdownlint"
 	]


### PR DESCRIPTION
Removing EditorConfig from the list of recommended extensions
Recommended formatting method is pre-commit gofmt